### PR TITLE
TimestampDescriptor

### DIFF
--- a/geocamUtil/models/TimestampDescriptor.py
+++ b/geocamUtil/models/TimestampDescriptor.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timedelta
+
+class TimestampDescriptor(object):
+    """
+    This descriptor class combines a second-resolution timestamp field with an 
+    auxilliary float field that represents microseconds.
+    """
+
+    def __init__(self, seconds_field, microseconds_field):
+        self.seconds_field = seconds_field
+        self.microseconds_field = microseconds_field
+
+    def __get__(self, instance, owner):
+        timestamp = getattr(instance, self.seconds_field)
+        assert isinstance(timestamp, datetime)
+        return timestamp + timedelta(microseconds=getattr(instance, self.microseconds_field))
+
+    def __set__(self, instance, value):
+        assert isinstance( value, datetime )
+        microseconds = value.microsecond
+        setattr(instance, self.seconds_field, value - timedelta(microseconds=microseconds) )
+        setattr(instance, self.microseconds_field, microseconds)

--- a/geocamUtil/models/__init__.py
+++ b/geocamUtil/models/__init__.py
@@ -9,6 +9,7 @@ from django.db import models
 from UuidField import UuidField
 from ExtrasField import ExtrasField
 from dateTimeUtc import DateTimeUtcField
+from TimestampDescriptor import TimestampDescriptor
 
 
 class UuidExample(models.Model):


### PR DESCRIPTION
This simple descriptor should work just as we talked about:

from geocamUtil.models import TimestampDescriptor

class Foo(Model):
  timestamp_seconds = DateTimeField()
  timestamp_micro = IntegerField()
  timestamp = TimestampDescriptor('timestamp_seconds', 'timestamp_micro')
