### PR TITLE
Implement PDF support when not using AppEngine

### DIFF
--- a/geocamUtil/pdf.py
+++ b/geocamUtil/pdf.py
@@ -4,8 +4,6 @@
 # All Rights Reserved.
 # __END_LICENSE__
 
-import PIL
-import StringIO
 import tempfile
 import os
 


### PR DESCRIPTION
For the cases where we don't use AppEngine (and thus we don't have access to the conversion.pdf library), we can use ImageMagick to generate pngs from the pdfs
